### PR TITLE
fix(autoload): add generated types for repo agent scan and fix db build

### DIFF
--- a/api/src/generated/types.ts
+++ b/api/src/generated/types.ts
@@ -52,6 +52,7 @@ export type AgentInstance = {
 };
 
 export enum AgentSource {
+  Autoloaded = 'AUTOLOADED',
   Default = 'DEFAULT',
   GlobalConfig = 'GLOBAL_CONFIG',
   Repository = 'REPOSITORY'
@@ -176,6 +177,7 @@ export type Mutation = {
   githubLogout: Scalars['Boolean']['output'];
   modifyAgent: AgentDefinitionPayload;
   registerRepository: RepositoryPayload;
+  reloadRepoAgents: RepoAgentScanPayload;
   removeRepository: RepositoryPayload;
   rerunTask: TaskPayload;
   resetAgentModification: AgentDefinitionPayload;
@@ -222,6 +224,11 @@ export type MutationModifyAgentArgs = {
 
 export type MutationRegisterRepositoryArgs = {
   input: RegisterRepositoryInput;
+};
+
+
+export type MutationReloadRepoAgentsArgs = {
+  repoName: Scalars['String']['input'];
 };
 
 
@@ -302,6 +309,7 @@ export type Query = {
   globalAgents: Array<AgentDefinition>;
   pipelineStatus?: Maybe<PipelineStatus>;
   repoAgentGroups: Array<RepoAgentGroup>;
+  repoAgentScan?: Maybe<RepoAgentScan>;
   repositories: Array<Repository>;
   repository?: Maybe<Repository>;
   task?: Maybe<Task>;
@@ -317,6 +325,11 @@ export type QueryGithubBranchesArgs = {
 
 export type QueryPipelineStatusArgs = {
   taskId: Scalars['ID']['input'];
+};
+
+
+export type QueryRepoAgentScanArgs = {
+  repoName: Scalars['String']['input'];
 };
 
 
@@ -352,6 +365,34 @@ export type RepoAgentGroup = {
   repoName: Scalars['String']['output'];
 };
 
+export type RepoAgentScan = {
+  __typename?: 'RepoAgentScan';
+  agentsCreated: Scalars['Int']['output'];
+  agentsFound: Scalars['Int']['output'];
+  completedAt?: Maybe<Scalars['DateTime']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  errorMessage?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  repoName: Scalars['String']['output'];
+  startedAt?: Maybe<Scalars['DateTime']['output']>;
+  status: RepoAgentScanStatus;
+};
+
+export type RepoAgentScanPayload = {
+  __typename?: 'RepoAgentScanPayload';
+  errors?: Maybe<Array<Error>>;
+  scan?: Maybe<RepoAgentScan>;
+};
+
+export enum RepoAgentScanStatus {
+  Analyzing = 'ANALYZING',
+  Completed = 'COMPLETED',
+  Failed = 'FAILED',
+  Pending = 'PENDING',
+  Scanning = 'SCANNING',
+  Writing = 'WRITING'
+}
+
 export type Repository = {
   __typename?: 'Repository';
   branch?: Maybe<Scalars['String']['output']>;
@@ -359,8 +400,10 @@ export type Repository = {
   cloneStatus: CloneStatus;
   deployPublicKey?: Maybe<Scalars['String']['output']>;
   errorMessage?: Maybe<Scalars['String']['output']>;
+  hasClaudeAgents: Scalars['Boolean']['output'];
   headSha?: Maybe<Scalars['String']['output']>;
   isConfigRepo: Scalars['Boolean']['output'];
+  lastAgentScan?: Maybe<RepoAgentScan>;
   lastClonedAt?: Maybe<Scalars['DateTime']['output']>;
   lastPulledAt?: Maybe<Scalars['DateTime']['output']>;
   name: Scalars['String']['output'];
@@ -576,6 +619,9 @@ export type ResolversTypes = ResolversObject<{
   Query: ResolverTypeWrapper<{}>;
   RegisterRepositoryInput: RegisterRepositoryInput;
   RepoAgentGroup: ResolverTypeWrapper<RepoAgentGroup>;
+  RepoAgentScan: ResolverTypeWrapper<RepoAgentScan>;
+  RepoAgentScanPayload: ResolverTypeWrapper<RepoAgentScanPayload>;
+  RepoAgentScanStatus: RepoAgentScanStatus;
   Repository: ResolverTypeWrapper<Repository>;
   RepositoryCount: ResolverTypeWrapper<RepositoryCount>;
   RepositoryPayload: ResolverTypeWrapper<RepositoryPayload>;
@@ -617,6 +663,8 @@ export type ResolversParentTypes = ResolversObject<{
   Query: {};
   RegisterRepositoryInput: RegisterRepositoryInput;
   RepoAgentGroup: RepoAgentGroup;
+  RepoAgentScan: RepoAgentScan;
+  RepoAgentScanPayload: RepoAgentScanPayload;
   Repository: Repository;
   RepositoryCount: RepositoryCount;
   RepositoryPayload: RepositoryPayload;
@@ -771,6 +819,7 @@ export type MutationResolvers<ContextType = Context, ParentType extends Resolver
   githubLogout?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   modifyAgent?: Resolver<ResolversTypes['AgentDefinitionPayload'], ParentType, ContextType, RequireFields<MutationModifyAgentArgs, 'name' | 'scope' | 'spec'>>;
   registerRepository?: Resolver<ResolversTypes['RepositoryPayload'], ParentType, ContextType, RequireFields<MutationRegisterRepositoryArgs, 'input'>>;
+  reloadRepoAgents?: Resolver<ResolversTypes['RepoAgentScanPayload'], ParentType, ContextType, RequireFields<MutationReloadRepoAgentsArgs, 'repoName'>>;
   removeRepository?: Resolver<ResolversTypes['RepositoryPayload'], ParentType, ContextType, RequireFields<MutationRemoveRepositoryArgs, 'name'>>;
   rerunTask?: Resolver<ResolversTypes['TaskPayload'], ParentType, ContextType, RequireFields<MutationRerunTaskArgs, 'id'>>;
   resetAgentModification?: Resolver<ResolversTypes['AgentDefinitionPayload'], ParentType, ContextType, RequireFields<MutationResetAgentModificationArgs, 'name' | 'scope'>>;
@@ -808,6 +857,7 @@ export type QueryResolvers<ContextType = Context, ParentType extends ResolversPa
   globalAgents?: Resolver<Array<ResolversTypes['AgentDefinition']>, ParentType, ContextType>;
   pipelineStatus?: Resolver<Maybe<ResolversTypes['PipelineStatus']>, ParentType, ContextType, RequireFields<QueryPipelineStatusArgs, 'taskId'>>;
   repoAgentGroups?: Resolver<Array<ResolversTypes['RepoAgentGroup']>, ParentType, ContextType>;
+  repoAgentScan?: Resolver<Maybe<ResolversTypes['RepoAgentScan']>, ParentType, ContextType, RequireFields<QueryRepoAgentScanArgs, 'repoName'>>;
   repositories?: Resolver<Array<ResolversTypes['Repository']>, ParentType, ContextType>;
   repository?: Resolver<Maybe<ResolversTypes['Repository']>, ParentType, ContextType, RequireFields<QueryRepositoryArgs, 'name'>>;
   task?: Resolver<Maybe<ResolversTypes['Task']>, ParentType, ContextType, RequireFields<QueryTaskArgs, 'id'>>;
@@ -820,14 +870,35 @@ export type RepoAgentGroupResolvers<ContextType = Context, ParentType extends Re
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type RepoAgentScanResolvers<ContextType = Context, ParentType extends ResolversParentTypes['RepoAgentScan'] = ResolversParentTypes['RepoAgentScan']> = ResolversObject<{
+  agentsCreated?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  agentsFound?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  completedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  errorMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  repoName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  startedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['RepoAgentScanStatus'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RepoAgentScanPayloadResolvers<ContextType = Context, ParentType extends ResolversParentTypes['RepoAgentScanPayload'] = ResolversParentTypes['RepoAgentScanPayload']> = ResolversObject<{
+  errors?: Resolver<Maybe<Array<ResolversTypes['Error']>>, ParentType, ContextType>;
+  scan?: Resolver<Maybe<ResolversTypes['RepoAgentScan']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type RepositoryResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Repository'] = ResolversParentTypes['Repository']> = ResolversObject<{
   branch?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   cloneDir?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   cloneStatus?: Resolver<ResolversTypes['CloneStatus'], ParentType, ContextType>;
   deployPublicKey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   errorMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  hasClaudeAgents?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   headSha?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   isConfigRepo?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  lastAgentScan?: Resolver<Maybe<ResolversTypes['RepoAgentScan']>, ParentType, ContextType>;
   lastClonedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   lastPulledAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -939,6 +1010,8 @@ export type Resolvers<ContextType = Context> = ResolversObject<{
   PipelineStatus?: PipelineStatusResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   RepoAgentGroup?: RepoAgentGroupResolvers<ContextType>;
+  RepoAgentScan?: RepoAgentScanResolvers<ContextType>;
+  RepoAgentScanPayload?: RepoAgentScanPayloadResolvers<ContextType>;
   Repository?: RepositoryResolvers<ContextType>;
   RepositoryCount?: RepositoryCountResolvers<ContextType>;
   RepositoryPayload?: RepositoryPayloadResolvers<ContextType>;

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.12-alpine
 
-RUN pip install --no-cache-dir "yoyo-migrations[postgres]"
+RUN apk add --no-cache postgresql-dev gcc musl-dev && \
+    pip install --no-cache-dir "yoyo-migrations[postgres]" && \
+    apk del gcc musl-dev
 
 WORKDIR /db
 

--- a/db/migrate.sh
+++ b/db/migrate.sh
@@ -10,15 +10,15 @@ shift 2>/dev/null || true
 case "$COMMAND" in
   apply)
     echo "==> Applying pending migrations..."
-    yoyo apply --batch --no-prompt -c /db/yoyo.ini "$@"
+    yoyo apply --batch  -c /db/yoyo.ini "$@"
     ;;
   rollback)
     echo "==> Rolling back last migration..."
-    yoyo rollback --batch --no-prompt -c /db/yoyo.ini "$@"
+    yoyo rollback --batch  -c /db/yoyo.ini "$@"
     ;;
   reapply)
     echo "==> Re-applying last migration (rollback + apply)..."
-    yoyo reapply --batch --no-prompt -c /db/yoyo.ini "$@"
+    yoyo reapply --batch  -c /db/yoyo.ini "$@"
     ;;
   list)
     echo "==> Listing migrations..."


### PR DESCRIPTION
- Add RepoAgentScan types, AUTOLOADED source enum, and reloadRepoAgents mutation to generated GraphQL types
- Fix db Dockerfile to install postgresql-dev build deps for psycopg
- Remove deprecated --no-prompt flag from yoyo migration commands